### PR TITLE
present Router's VCs on topViewController

### DIFF
--- a/Sources/MailRoute/MailRoute.swift
+++ b/Sources/MailRoute/MailRoute.swift
@@ -34,7 +34,7 @@ public extension MailRoute where Self: Router {
         }
         controller.setPreferredSendingEmailAddress(parameters.preferredSendingEmailAddress)
 
-        viewController?.present(controller, animated: true, completion: nil)
+        topViewController?.present(controller, animated: true, completion: nil)
         return controller
     }
 

--- a/Sources/PhotoRoute/PhotoRouter.swift
+++ b/Sources/PhotoRoute/PhotoRouter.swift
@@ -123,6 +123,6 @@ public extension PhotoRoute where Self: Router {
 
         imagePickerController.delegate = delegate
         imagePickerController.presentationController?.delegate = delegate
-        viewController?.present(imagePickerController, animated: true)
+        topViewController?.present(imagePickerController, animated: true)
     }
 }

--- a/Sources/Routes/AlertRoute.swift
+++ b/Sources/Routes/AlertRoute.swift
@@ -17,7 +17,7 @@ public extension AlertRoute where Self: Router {
                                                     preferredStyle: preferredStyle)
         actions.forEach { action in
             alertViewController.addAction(action)
-        }            
-        viewController?.present(alertViewController, animated: true, completion: nil)
+        }
+        topViewController?.present(alertViewController, animated: true, completion: nil)
     }
 }

--- a/Sources/Routes/ShareRoute.swift
+++ b/Sources/Routes/ShareRoute.swift
@@ -35,6 +35,6 @@ public extension ShareRoute where Self: Router {
         activityViewController.completionWithItemsHandler = { _, completed, _, _ in
             completion?(completed)
         }
-        viewController?.present(activityViewController, animated: true, completion: nil)
+        topViewController?.present(activityViewController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
Use `topViewController` when presenting Router's VC (such as MFMailViewController, ImagePicker and UIActivityViewController) instead of just `viewController` since `viewController` may be not on top, but presentation should be on top